### PR TITLE
Support different types of encoding for subscription client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/onosproject/onos-ric-sdk-go
 go 1.15
 
 require (
-	github.com/gogo/protobuf v1.3.1
+	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/go-cmp v0.5.1 // indirect
 	github.com/google/uuid v1.1.2
@@ -18,5 +18,5 @@ require (
 	golang.org/x/text v0.3.3 // indirect
 	google.golang.org/genproto v0.0.0-20200731012542-8145dea6a485
 	google.golang.org/grpc v1.33.1
-	google.golang.org/protobuf v1.25.0 // indirect
+	google.golang.org/protobuf v1.25.0
 )

--- a/pkg/e2/encoding/encoding.go
+++ b/pkg/e2/encoding/encoding.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+//
+// SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+package encoding
+
+// Type encoding type (asn.1 or protobuf)
+type Type int32
+
+const (
+	ASN1 Type = iota
+	PROTO
+)
+
+func (t Type) String() string {
+	return [...]string{"ASN.1", "PROTO"}[t]
+}

--- a/pkg/e2/indication/indication.go
+++ b/pkg/e2/indication/indication.go
@@ -4,7 +4,18 @@
 
 package indication
 
+import "github.com/onosproject/onos-ric-sdk-go/pkg/e2/encoding"
+
 // Indication is an E2 indication
 type Indication struct {
+	// EncodingType payload encoding type
+	EncodingType encoding.Type
 
+	// Payload is the indication payload
+	Payload Payload
+}
+
+// E2 indication payload
+type Payload struct {
+	Value interface{}
 }

--- a/pkg/e2/subscription/subscription.go
+++ b/pkg/e2/subscription/subscription.go
@@ -5,13 +5,16 @@
 package subscription
 
 import (
-	"github.com/gogo/protobuf/proto"
+	"github.com/onosproject/onos-ric-sdk-go/pkg/e2/encoding"
 	"github.com/onosproject/onos-ric-sdk-go/pkg/e2/node"
 	"github.com/onosproject/onos-ric-sdk-go/pkg/e2/sm"
+	"google.golang.org/protobuf/proto"
 )
 
 // Subscription is an E2 subscription
 type Subscription struct {
+	// EncodingType payload encoding type
+	EncodingType encoding.Type
 	// NodeID is the E2 node identifier
 	NodeID node.ID
 	// ServiceModel is the service model
@@ -21,4 +24,11 @@ type Subscription struct {
 }
 
 // Payload is an E2 subscription payload
-type Payload proto.Message
+type Payload struct {
+	Value interface{}
+}
+
+// GetProtoValue
+func (p *Payload) GetProtoValue() ([]byte, error) {
+	return proto.Marshal(p.Value.(proto.Message))
+}


### PR DESCRIPTION
This PR adds an encoding package and make the required changes that allows to support different type of payloads (i.e. in terms of encoding). 