### PR TITLE
Fix local variable in test proxy start/stop functions

### DIFF
--- a/pkg/utils/test_proxy.go
+++ b/pkg/utils/test_proxy.go
@@ -7,7 +7,6 @@ package utils
 import (
 	"fmt"
 	"github.com/onosproject/onos-lib-go/pkg/certs"
-	"github.com/onosproject/onos-lib-go/pkg/logging"
 	"github.com/onosproject/onos-proxy/pkg/manager"
 	"io/ioutil"
 	"os"
@@ -34,8 +33,7 @@ func StartTestProxy() {
 		GRPCPort: 5151,
 	}
 
-	logging.GetLogger("e2", "v1beta1").SetLevel(logging.WarnLevel)
-	mgr := manager.NewManager(cfg)
+	mgr = manager.NewManager(cfg)
 	mgr.Run()
 }
 


### PR DESCRIPTION
Fixes a bug in the test proxy start/stop functions. The package-scoped `mgr` variable is declared, but the `StartTestProxy()` function actually assigns the proxy manager to a function-scoped variable rather than using the package-scoped variable (`:=` rather than `=`).