### PR TITLE
Cache Nodes in E2 client to prevent resource leaks when calling Node()

### DIFF
--- a/pkg/e2/v1beta1/client.go
+++ b/pkg/e2/v1beta1/client.go
@@ -6,6 +6,7 @@ package e2
 
 import (
 	"github.com/onosproject/onos-lib-go/pkg/logging"
+	"sync"
 )
 
 var log = logging.GetLogger("e2", "v1beta1")
@@ -19,17 +20,42 @@ type Client interface {
 // NewClient creates a new E2 client
 func NewClient(opts ...Option) Client {
 	return &e2Client{
-		opts: opts,
+		opts:  opts,
+		nodes: make(map[NodeID]Node),
 	}
 }
 
 // e2Client is the default E2 client implementation
 type e2Client struct {
-	opts []Option
+	opts  []Option
+	nodes map[NodeID]Node
+	mu    sync.RWMutex
 }
 
 func (c *e2Client) Node(nodeID NodeID) Node {
-	return NewNode(nodeID, c.opts...)
+	c.mu.RLock()
+	node, ok := c.nodes[nodeID]
+	c.mu.RUnlock()
+	if ok {
+		return node
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	node, ok = c.nodes[nodeID]
+	if ok {
+		return node
+	}
+
+	node = NewNode(nodeID, c.opts...)
+	c.nodes[nodeID] = node
+	go func() {
+		<-node.Context().Done()
+		c.mu.Lock()
+		delete(c.nodes, nodeID)
+		c.mu.Unlock()
+	}()
+	return node
 }
 
 var _ Client = &e2Client{}


### PR DESCRIPTION
Fixes a resource leak in the E2 client.